### PR TITLE
Add typed Workflow.ReplayWorkflow method for positional workflow replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ There are two functions in this library that make it easy to write fixture based
 See `example/replay_test.go` for an example of how to use them.
 ```go
 func GetWorkflowHistoriesBundle(ctx context.Context, client *tempts.Client, w tempts.WorkflowDeclaration) ([]byte, error)
-func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions) error
-// Or use the typed method on Workflow, which handles positional workflows automatically:
 func (w Workflow[Param, Return]) ReplayWorkflow(historiesBytes []byte, fn func(workflow.Context, Param) (Return, error), opts worker.WorkflowReplayerOptions) error
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ Signals:
 
 ### Tools
 
-There are two functions in this library that make it easy to write fixture based replyabaility tests for your tempts workflows and activities.
-See `example/main_test.go` for an example of how to use them.
+There are two functions in this library that make it easy to write fixture based replayability tests for your tempts workflows and activities.
+See `example/replay_test.go` for an example of how to use them.
 ```go
-func GetWorkflowHistoriesBundle(ctx context.Context, client *tempts.Client, w *tempts.WorkflowWithImpl) ([]byte, error)
-func ReplayWorkflow(historiesBytes []byte, w *tempts.WorkflowWithImpl, opts worker.WorkflowReplayerOptions) error
+func GetWorkflowHistoriesBundle(ctx context.Context, client *tempts.Client, w tempts.WorkflowDeclaration) ([]byte, error)
+func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions) error
+// Or use the typed method on Workflow, which handles positional workflows automatically:
+func (w Workflow[Param, Return]) ReplayWorkflow(historiesBytes []byte, fn func(workflow.Context, Param) (Return, error), opts worker.WorkflowReplayerOptions) error
 ```
 
 ## User guide by example
@@ -310,7 +312,7 @@ if err != nil {
     t.Fatal(err)
 }
 // Now store historiesData somewhere! (Or don't and make sure your test is always connected to a temporal instance with example workflow runs)
-err := tempts.ReplayWorkflow(historiesData, exampleWorkflow, worker.WorkflowReplayerOptions{})
+err := exampleWorkflowType.ReplayWorkflow(historiesData, exampleWorkflow, worker.WorkflowReplayerOptions{})
 if err != nil {
     t.Fatal(err)
 }

--- a/example/replay_test.go
+++ b/example/replay_test.go
@@ -22,10 +22,6 @@ func init() {
 func TestFormatAndGreetReplayability(t *testing.T) {
 	filename := fmt.Sprintf("histories/%s.json", workflowTypeFormatAndGreet.Name())
 
-	testReplayability(t, workflowTypeFormatAndGreet, workflowFormatAndGreet, filename)
-}
-
-func testReplayability(t *testing.T, workflowDeclaration tempts.WorkflowDeclaration, fn any, filename string) {
 	var historiesData []byte
 	if record {
 		ctx := context.Background()
@@ -33,7 +29,7 @@ func testReplayability(t *testing.T, workflowDeclaration tempts.WorkflowDeclarat
 		if err != nil {
 			t.Fatal(err)
 		}
-		historiesData, err = tempts.GetWorkflowHistoriesBundle(ctx, c, workflowDeclaration)
+		historiesData, err = tempts.GetWorkflowHistoriesBundle(ctx, c, workflowTypeFormatAndGreet)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -50,7 +46,7 @@ func testReplayability(t *testing.T, workflowDeclaration tempts.WorkflowDeclarat
 		}
 	}
 
-	err := tempts.ReplayWorkflow(historiesData, fn, worker.WorkflowReplayerOptions{})
+	err := workflowTypeFormatAndGreet.ReplayWorkflow(historiesData, workflowFormatAndGreet, worker.WorkflowReplayerOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/replaytest.go
+++ b/replaytest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	"go.temporal.io/api/enums/v1"
@@ -89,9 +90,54 @@ type historiesData struct {
 }
 
 // ReplayWorkflow is meant to be used in tests with the output of GetWorkflowHistoriesBundle to check if the given workflow implementation (fn) is compatible with previous executions captured at the time when GetWorkflowHistoriesBundle was run.
-// The optional decl parameter, when provided, allows positional workflows to be correctly
-// wrapped for replay compatibility with histories that used positional arguments.
-func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions, decl ...WorkflowDeclaration) error {
+func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions) error {
+	return replayWorkflow(historiesBytes, fn, opts)
+}
+
+// ReplayWorkflow is a typed version of the package-level ReplayWorkflow that handles positional
+// workflow replay automatically. For positional workflows, fn is wrapped to accept positional
+// arguments matching the on-wire format before reconstructing the Param struct.
+func (w Workflow[Param, Return]) ReplayWorkflow(historiesBytes []byte, fn func(workflow.Context, Param) (Return, error), opts worker.WorkflowReplayerOptions) error {
+	if !w.positional {
+		return replayWorkflow(historiesBytes, fn, opts)
+	}
+
+	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	var fieldTypes []reflect.Type
+	if paramType.Kind() == reflect.Ptr {
+		fieldTypes = extractFieldTypes(paramType.Elem())
+	} else {
+		fieldTypes = extractFieldTypes(paramType)
+	}
+
+	fnVal := reflect.ValueOf(fn)
+	wrapper := reflect.MakeFunc(
+		reflect.FuncOf(
+			append([]reflect.Type{reflect.TypeOf((*workflow.Context)(nil)).Elem()}, fieldTypes...),
+			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
+			false,
+		),
+		func(args []reflect.Value) []reflect.Value {
+			var paramVal reflect.Value
+			if paramType.Kind() == reflect.Ptr {
+				paramVal = reflect.New(paramType.Elem())
+				for i := 0; i < paramType.Elem().NumField(); i++ {
+					paramVal.Elem().Field(i).Set(args[i+1])
+				}
+			} else {
+				paramVal = reflect.New(paramType).Elem()
+				for i := 0; i < paramType.NumField(); i++ {
+					paramVal.Field(i).Set(args[i+1])
+				}
+			}
+			return fnVal.Call([]reflect.Value{args[0], paramVal})
+		},
+	)
+
+	return replayWorkflow(historiesBytes, wrapper.Interface(), opts)
+}
+
+func replayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions) error {
 	var historiesData historiesData
 	err := json.Unmarshal(historiesBytes, &historiesData)
 	if err != nil {
@@ -104,11 +150,7 @@ func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerO
 	if err != nil {
 		return fmt.Errorf("failed to create replayer: %w", err)
 	}
-	registeredFn := fn
-	if len(decl) > 0 && decl[0] != nil {
-		registeredFn = decl[0].wrapForReplay(fn)
-	}
-	replayer.RegisterWorkflowWithOptions(registeredFn, workflow.RegisterOptions{
+	replayer.RegisterWorkflowWithOptions(fn, workflow.RegisterOptions{
 		Name: historiesData.WorkflowName,
 	})
 	for _, histData := range historiesData.Histories {
@@ -117,11 +159,11 @@ func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerO
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal history: %w", err)
 		}
-		opts := worker.ReplayWorkflowHistoryOptions{}
-		opts.OriginalExecution.ID = histData.WorkflowID
-		opts.OriginalExecution.RunID = histData.RunID
+		replayOpts := worker.ReplayWorkflowHistoryOptions{}
+		replayOpts.OriginalExecution.ID = histData.WorkflowID
+		replayOpts.OriginalExecution.RunID = histData.RunID
 
-		err = replayer.ReplayWorkflowHistoryWithOptions(nil, &h, opts)
+		err = replayer.ReplayWorkflowHistoryWithOptions(nil, &h, replayOpts)
 		if err != nil {
 			return fmt.Errorf("failed to replay workflow %s: %w", historiesData.WorkflowName, err)
 		}

--- a/replaytest.go
+++ b/replaytest.go
@@ -89,7 +89,9 @@ type historiesData struct {
 }
 
 // ReplayWorkflow is meant to be used in tests with the output of GetWorkflowHistoriesBundle to check if the given workflow implementation (fn) is compatible with previous executions captured at the time when GetWorkflowHistoriesBundle was run.
-func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions) error {
+// The optional decl parameter, when provided, allows positional workflows to be correctly
+// wrapped for replay compatibility with histories that used positional arguments.
+func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerOptions, decl ...WorkflowDeclaration) error {
 	var historiesData historiesData
 	err := json.Unmarshal(historiesBytes, &historiesData)
 	if err != nil {
@@ -102,7 +104,11 @@ func ReplayWorkflow(historiesBytes []byte, fn any, opts worker.WorkflowReplayerO
 	if err != nil {
 		return fmt.Errorf("failed to create replayer: %w", err)
 	}
-	replayer.RegisterWorkflowWithOptions(fn, workflow.RegisterOptions{
+	registeredFn := fn
+	if len(decl) > 0 && decl[0] != nil {
+		registeredFn = decl[0].wrapForReplay(fn)
+	}
+	replayer.RegisterWorkflowWithOptions(registeredFn, workflow.RegisterOptions{
 		Name: historiesData.WorkflowName,
 	})
 	for _, histData := range historiesData.Histories {

--- a/workflow.go
+++ b/workflow.go
@@ -63,6 +63,11 @@ func (w WorkflowWithImpl[Param, Return]) ExecuteInTest(e testEnvironment, p Para
 type WorkflowDeclaration interface {
 	Name() string
 	getQueue() *Queue
+	// wrapForReplay wraps a workflow function for replay compatibility.
+	// For positional workflows, this converts the struct-parameter function into
+	// a positional-parameter function matching the on-wire format.
+	// For non-positional workflows, this returns fn unchanged.
+	wrapForReplay(fn any) any
 }
 
 // Workflow is used for interacting with workflows in a safe way that takes into account the input and output types, queue name and other properties.
@@ -138,6 +143,51 @@ func (w Workflow[Param, Return]) Name() string {
 // getQueue returns the queue for the workflow
 func (w Workflow[Param, Return]) getQueue() *Queue {
 	return w.queue
+}
+
+// wrapForReplay wraps fn for replay compatibility. For positional workflows,
+// it creates a function with positional parameters that reconstructs the struct
+// before calling fn. For non-positional workflows, it returns fn unchanged.
+func (w Workflow[Param, Return]) wrapForReplay(fn any) any {
+	if !w.positional {
+		return fn
+	}
+
+	// fn must be func(workflow.Context, Param) (Return, error)
+	fnVal := reflect.ValueOf(fn)
+
+	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	var fieldTypes []reflect.Type
+	if paramType.Kind() == reflect.Ptr {
+		fieldTypes = extractFieldTypes(paramType.Elem())
+	} else {
+		fieldTypes = extractFieldTypes(paramType)
+	}
+
+	wrapper := reflect.MakeFunc(
+		reflect.FuncOf(
+			append([]reflect.Type{reflect.TypeOf((*workflow.Context)(nil)).Elem()}, fieldTypes...),
+			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
+			false,
+		),
+		func(args []reflect.Value) []reflect.Value {
+			var paramVal reflect.Value
+			if paramType.Kind() == reflect.Ptr {
+				paramVal = reflect.New(paramType.Elem())
+				for i := 0; i < paramType.Elem().NumField(); i++ {
+					paramVal.Elem().Field(i).Set(args[i+1])
+				}
+			} else {
+				paramVal = reflect.New(paramType).Elem()
+				for i := 0; i < paramType.NumField(); i++ {
+					paramVal.Field(i).Set(args[i+1])
+				}
+			}
+			return fnVal.Call([]reflect.Value{args[0], paramVal})
+		},
+	)
+
+	return wrapper.Interface()
 }
 
 // WithImplementation should be called to create the parameters for NewWorker(). It declares which function implements the workflow.

--- a/workflow.go
+++ b/workflow.go
@@ -63,11 +63,6 @@ func (w WorkflowWithImpl[Param, Return]) ExecuteInTest(e testEnvironment, p Para
 type WorkflowDeclaration interface {
 	Name() string
 	getQueue() *Queue
-	// wrapForReplay wraps a workflow function for replay compatibility.
-	// For positional workflows, this converts the struct-parameter function into
-	// a positional-parameter function matching the on-wire format.
-	// For non-positional workflows, this returns fn unchanged.
-	wrapForReplay(fn any) any
 }
 
 // Workflow is used for interacting with workflows in a safe way that takes into account the input and output types, queue name and other properties.
@@ -143,51 +138,6 @@ func (w Workflow[Param, Return]) Name() string {
 // getQueue returns the queue for the workflow
 func (w Workflow[Param, Return]) getQueue() *Queue {
 	return w.queue
-}
-
-// wrapForReplay wraps fn for replay compatibility. For positional workflows,
-// it creates a function with positional parameters that reconstructs the struct
-// before calling fn. For non-positional workflows, it returns fn unchanged.
-func (w Workflow[Param, Return]) wrapForReplay(fn any) any {
-	if !w.positional {
-		return fn
-	}
-
-	// fn must be func(workflow.Context, Param) (Return, error)
-	fnVal := reflect.ValueOf(fn)
-
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
-	var fieldTypes []reflect.Type
-	if paramType.Kind() == reflect.Ptr {
-		fieldTypes = extractFieldTypes(paramType.Elem())
-	} else {
-		fieldTypes = extractFieldTypes(paramType)
-	}
-
-	wrapper := reflect.MakeFunc(
-		reflect.FuncOf(
-			append([]reflect.Type{reflect.TypeOf((*workflow.Context)(nil)).Elem()}, fieldTypes...),
-			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
-			false,
-		),
-		func(args []reflect.Value) []reflect.Value {
-			var paramVal reflect.Value
-			if paramType.Kind() == reflect.Ptr {
-				paramVal = reflect.New(paramType.Elem())
-				for i := 0; i < paramType.Elem().NumField(); i++ {
-					paramVal.Elem().Field(i).Set(args[i+1])
-				}
-			} else {
-				paramVal = reflect.New(paramType).Elem()
-				for i := 0; i < paramType.NumField(); i++ {
-					paramVal.Field(i).Set(args[i+1])
-				}
-			}
-			return fnVal.Call([]reflect.Value{args[0], paramVal})
-		},
-	)
-
-	return wrapper.Interface()
 }
 
 // WithImplementation should be called to create the parameters for NewWorker(). It declares which function implements the workflow.


### PR DESCRIPTION
ReplayWorkflow was registering workflow functions directly without the positional parameter wrapper, causing
  replay failures for workflows declared with NewWorkflowPositional. The recorded histories contain positional
  arguments but the registered function expects a single struct.

  This adds a typed Workflow[Param, Return].ReplayWorkflow() method that handles positional wrapping internally.
  The package-level ReplayWorkflow() keeps its original signature unchanged.

  Usage for positional workflows:
  err := myWorkflow.ReplayWorkflow(historiesData, myWorkflowImpl, opts)

  Usage for non-positional workflows (unchanged):
  err := tempts.ReplayWorkflow(historiesData, myWorkflowImpl, opts)