### PR TITLE
Enforce service-bound Nexus clients during operation execution

### DIFF
--- a/nexus.go
+++ b/nexus.go
@@ -215,15 +215,32 @@ func (s *Service) WithImplementations(ops ...OperationWithImpl) (*ServiceWithImp
 
 // NexusClient is used to call Nexus operations from within a workflow.
 type NexusClient struct {
-	client workflow.NexusClient
+	client      workflow.NexusClient
+	serviceName string
 }
 
 // NewClient creates a NexusClient for calling operations on this service.
 // The endpoint parameter specifies the Nexus endpoint to use.
 func (s *Service) NewClient(ctx workflow.Context, endpoint string) *NexusClient {
 	return &NexusClient{
-		client: workflow.NewNexusClient(endpoint, s.name),
+		client:      workflow.NewNexusClient(endpoint, s.name),
+		serviceName: s.name,
 	}
+}
+
+func validateServiceMatch(opName string, opService *Service, c *NexusClient) error {
+	if c == nil {
+		return fmt.Errorf("cannot execute operation %s on service %s with nil Nexus client", opName, opService.name)
+	}
+	if c.serviceName != opService.name {
+		return fmt.Errorf(
+			"cannot execute operation %s on service %s with client for service %s",
+			opName,
+			opService.name,
+			c.serviceName,
+		)
+	}
+	return nil
 }
 
 // Run synchronously executes a sync operation and returns the result.
@@ -246,6 +263,11 @@ func (op SyncOperation[Param, Return]) Execute(
 	param Param,
 	opts workflow.NexusOperationOptions,
 ) workflow.NexusOperationFuture {
+	// ExecuteOperation does not return an error, so we panic with an explicit
+	// message for invalid client/service pairing to fail fast during workflow execution.
+	if err := validateServiceMatch(op.name, op.service, c); err != nil {
+		panic(err.Error())
+	}
 	return c.client.ExecuteOperation(ctx, op.name, param, opts)
 }
 
@@ -269,5 +291,10 @@ func (op AsyncOperation[Param, Return]) Execute(
 	param Param,
 	opts workflow.NexusOperationOptions,
 ) workflow.NexusOperationFuture {
+	// ExecuteOperation does not return an error, so we panic with an explicit
+	// message for invalid client/service pairing to fail fast during workflow execution.
+	if err := validateServiceMatch(op.name, op.service, c); err != nil {
+		panic(err.Error())
+	}
 	return c.client.ExecuteOperation(ctx, op.name, param, opts)
 }

--- a/nexus_test.go
+++ b/nexus_test.go
@@ -120,3 +120,54 @@ func TestOperationPanicIfNotStruct(t *testing.T) {
 		})
 	})
 }
+
+func TestOperationExecutePanicsOnMismatchedClientService(t *testing.T) {
+	t.Run("sync operation with client from different service", func(t *testing.T) {
+		svcA := NewService("service-a")
+		svcB := NewService("service-b")
+
+		syncA := NewSyncOperation[testInput, testOutput](svcA, "shared-op")
+		_ = NewSyncOperation[testInput, testOutput](svcB, "shared-op")
+
+		clientB := &NexusClient{serviceName: svcB.name}
+
+		require.PanicsWithValue(
+			t,
+			"cannot execute operation shared-op on service service-a with client for service service-b",
+			func() {
+				syncA.Execute(nil, clientB, testInput{}, workflow.NexusOperationOptions{})
+			},
+		)
+	})
+
+	t.Run("async operation with client from different service", func(t *testing.T) {
+		svcA := NewService("service-a")
+		svcB := NewService("service-b")
+
+		asyncA := NewAsyncOperation[testInput, testOutput](svcA, "shared-op")
+		_ = NewAsyncOperation[testInput, testOutput](svcB, "shared-op")
+
+		clientB := &NexusClient{serviceName: svcB.name}
+
+		require.PanicsWithValue(
+			t,
+			"cannot execute operation shared-op on service service-a with client for service service-b",
+			func() {
+				asyncA.Execute(nil, clientB, testInput{}, workflow.NexusOperationOptions{})
+			},
+		)
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		svc := NewService("service-a")
+		syncOp := NewSyncOperation[testInput, testOutput](svc, "op")
+
+		require.PanicsWithValue(
+			t,
+			"cannot execute operation op on service service-a with nil Nexus client",
+			func() {
+				syncOp.Execute(nil, nil, testInput{}, workflow.NexusOperationOptions{})
+			},
+		)
+	})
+}


### PR DESCRIPTION
### Motivation
- Prevent operations from being executed with a Nexus client that was created for a different `Service`, which can cause routing and authorization mistakes. 
- Fail fast with clear diagnostics including operation and service names to make routing errors straightforward to debug.

### Description
- Extended `NexusClient` to carry the originating service identity via a new `serviceName` field and updated `(*Service).NewClient` to populate it. 
- Added a shared validation helper `validateServiceMatch(opName string, opService *Service, c *NexusClient) error` that checks for a nil client and enforces that `c.serviceName` matches `op.service`. 
- Invoked the validation from both `SyncOperation.Execute` and `AsyncOperation.Execute`, and chose to `panic` with an explicit message when validation fails because `Execute` returns a `workflow.NexusOperationFuture` and cannot return an error. 
- Added tests in `nexus_test.go` (`TestOperationExecutePanicsOnMismatchedClientService`) that cover mismatched-client usage for sync and async operations, overlapping operation names, and a nil-client case, and included error messages with operation and service names. 

### Testing
- Ran `go test ./...` and all tests passed. 
- New test `TestOperationExecutePanicsOnMismatchedClientService` verifies sync/async mismatched-client panics and nil-client panic and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5640e4d4832ab8fdee2266c8d1ba)