### PR TITLE
fix temporal worker start and stop race

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -83,10 +83,10 @@ func (w *Worker) Run(ctx context.Context, client *Client, options worker.Options
 	wrk := worker.New(client.Client, w.queue.name, options)
 	w.Register(wrk)
 
+	interruptCh := make(chan interface{})
 	go func() {
-		// There's no way to pass the channel from ctx.Done directly into Run because it's of the wrong type.
 		<-ctx.Done()
-		wrk.Stop()
+		close(interruptCh)
 	}()
-	return wrk.Run(nil)
+	return wrk.Run(interruptCh)
 }

--- a/workflow.go
+++ b/workflow.go
@@ -328,7 +328,7 @@ func setSchedule(ctx context.Context, temporalClient *Client, opts client.Schedu
 	opts.Action = a
 
 	s := temporalClient.Client.ScheduleClient().GetHandle(ctx, opts.ID)
-	info, err := s.Describe(ctx)
+	_, err := s.Describe(ctx)
 	if err != nil {
 		var notFound *serviceerror.NotFound
 		if !errors.As(err, &notFound) {


### PR DESCRIPTION
## Why?
* Risk of race between temporal start and stop when the pod is crashlooping for other reasons. 
* Runnable 1 crashes, ctx is closed while temporal runnable is starting then can cause a race condition (in stdtemporal I only could do this when adding a delay in the runnable but in tempts is consistent)
* Floods logs of pods with the message 

## What is the fix?
* Passing a channel to the Run function
* Closing the channel when ctx is done
* Run has logic to avoid race conditions between Start and Stop

## Tests
* Reproduced the race condition locally


