### PR TITLE
fix: decompose positional args in SignalWithStart

### DIFF
--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -1,0 +1,24 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vikstrous/tempts"
+	"go.temporal.io/sdk/worker"
+)
+
+func startWorker(t *testing.T, queue *tempts.Queue, registerables []tempts.Registerable) {
+	t.Helper()
+	wrk, err := tempts.NewWorker(queue, registerables)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		if err := wrk.Run(ctx, testClient, worker.Options{}); err != nil {
+			t.Logf("worker stopped: %v", err)
+		}
+	}()
+}

--- a/integration_test/main_test.go
+++ b/integration_test/main_test.go
@@ -1,0 +1,37 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/vikstrous/tempts"
+	"go.temporal.io/sdk/testsuite"
+)
+
+var testClient *tempts.Client
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	srv, err := testsuite.StartDevServer(ctx, testsuite.DevServerOptions{
+		LogLevel: "error",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start dev server: %v\n", err)
+		os.Exit(1)
+	}
+
+	testClient, err = tempts.NewFromSDK(srv.Client(), "default")
+	if err != nil {
+		srv.Stop()
+		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	srv.Stop()
+	os.Exit(code)
+}

--- a/integration_test/signal_with_start_test.go
+++ b/integration_test/signal_with_start_test.go
@@ -1,0 +1,119 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/vikstrous/tempts"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+// -- Positional workflow declarations --
+
+var queuePositionalSignal = tempts.NewQueue("positional_signal_test")
+
+type PositionalSignalParams struct {
+	FirstName string
+	LastName  string
+}
+
+type PositionalSignalResult struct {
+	Greeting string
+}
+
+var workflowPositionalSignal = tempts.NewWorkflowPositional[PositionalSignalParams, PositionalSignalResult](queuePositionalSignal, "positional_signal_wf")
+
+type SignalSuffix struct {
+	Suffix string
+}
+
+var signalPositional = tempts.NewWorkflowSignal[SignalSuffix](&workflowPositionalSignal, "suffix_signal")
+
+func workflowPositionalSignalImpl(ctx workflow.Context, params PositionalSignalParams) (PositionalSignalResult, error) {
+	greeting := fmt.Sprintf("Hello %s %s", params.FirstName, params.LastName)
+	if sig, ok := signalPositional.TryReceive(ctx); ok {
+		greeting += sig.Suffix
+	}
+	return PositionalSignalResult{Greeting: greeting}, nil
+}
+
+// -- Non-positional workflow declarations (control) --
+
+var queueNonPositionalSignal = tempts.NewQueue("non_positional_signal_test")
+
+type NonPositionalSignalParams struct {
+	FirstName string
+	LastName  string
+}
+
+type NonPositionalSignalResult struct {
+	Greeting string
+}
+
+var workflowNonPositionalSignal = tempts.NewWorkflow[NonPositionalSignalParams, NonPositionalSignalResult](queueNonPositionalSignal, "non_positional_signal_wf")
+
+var signalNonPositional = tempts.NewWorkflowSignal[SignalSuffix](&workflowNonPositionalSignal, "suffix_signal")
+
+func workflowNonPositionalSignalImpl(ctx workflow.Context, params NonPositionalSignalParams) (NonPositionalSignalResult, error) {
+	greeting := fmt.Sprintf("Hello %s %s", params.FirstName, params.LastName)
+	if sig, ok := signalNonPositional.TryReceive(ctx); ok {
+		greeting += sig.Suffix
+	}
+	return NonPositionalSignalResult{Greeting: greeting}, nil
+}
+
+// -- Tests --
+
+func TestSignalWithStartPositional(t *testing.T) {
+	startWorker(t, queuePositionalSignal, []tempts.Registerable{
+		workflowPositionalSignal.WithImplementation(workflowPositionalSignalImpl),
+	})
+
+	run, err := signalPositional.SignalWithStart(
+		context.Background(), testClient,
+		client.StartWorkflowOptions{ID: "test-positional-signal-with-start"},
+		PositionalSignalParams{FirstName: "Alice", LastName: "Smith"},
+		SignalSuffix{Suffix: "!"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result PositionalSignalResult
+	if err := run.Get(context.Background(), &result); err != nil {
+		t.Fatalf("workflow failed (likely positional arg mismatch on wire): %v", err)
+	}
+
+	expected := "Hello Alice Smith!"
+	if result.Greeting != expected {
+		t.Fatalf("expected %q, got %q", expected, result.Greeting)
+	}
+}
+
+func TestSignalWithStartNonPositional(t *testing.T) {
+	startWorker(t, queueNonPositionalSignal, []tempts.Registerable{
+		workflowNonPositionalSignal.WithImplementation(workflowNonPositionalSignalImpl),
+	})
+
+	run, err := signalNonPositional.SignalWithStart(
+		context.Background(), testClient,
+		client.StartWorkflowOptions{ID: "test-non-positional-signal-with-start"},
+		NonPositionalSignalParams{FirstName: "Bob", LastName: "Jones"},
+		SignalSuffix{Suffix: "?"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result NonPositionalSignalResult
+	if err := run.Get(context.Background(), &result); err != nil {
+		t.Fatalf("workflow failed: %v", err)
+	}
+
+	expected := "Hello Bob Jones?"
+	if result.Greeting != expected {
+		t.Fatalf("expected %q, got %q", expected, result.Greeting)
+	}
+}

--- a/signal.go
+++ b/signal.go
@@ -2,6 +2,7 @@ package tempts
 
 import (
 	"context"
+	"reflect"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
@@ -95,6 +96,21 @@ func (s *WorkflowSignal[WP, WR, SP]) SignalWithStart(
 	signalParam SP,
 ) (client.WorkflowRun, error) {
 	opts.TaskQueue = s.workflow.queue.name
+
+	var workflowArgs []any
+	if !s.workflow.positional {
+		workflowArgs = []any{workflowParam}
+	} else {
+		paramVal := reflect.ValueOf(workflowParam)
+		if paramVal.Kind() == reflect.Ptr {
+			paramVal = paramVal.Elem()
+		}
+		workflowArgs = make([]any, paramVal.NumField())
+		for i := 0; i < paramVal.NumField(); i++ {
+			workflowArgs[i] = paramVal.Field(i).Interface()
+		}
+	}
+
 	return temporalClient.Client.SignalWithStartWorkflow(
 		ctx,
 		opts.ID,
@@ -102,6 +118,6 @@ func (s *WorkflowSignal[WP, WR, SP]) SignalWithStart(
 		signalParam,
 		opts,
 		s.workflow.name,
-		workflowParam,
+		workflowArgs...,
 	)
 }

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,81 @@
+package tempts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+)
+
+// signalWithStartCapture is a minimal mock that captures the workflowArgs
+// passed to SignalWithStartWorkflow. Only this method is implemented; calling
+// any other client.Client method will panic (which is fine for these tests).
+type signalWithStartCapture struct {
+	client.Client
+	capturedWorkflowArgs []any
+}
+
+func (c *signalWithStartCapture) SignalWithStartWorkflow(
+	ctx context.Context, workflowID string, signalName string,
+	signalArg any, options client.StartWorkflowOptions,
+	workflow any, workflowArgs ...any,
+) (client.WorkflowRun, error) {
+	c.capturedWorkflowArgs = workflowArgs
+	return nil, nil
+}
+
+type signalTestParams struct {
+	Name string
+	Age  int
+}
+
+type signalTestResult struct {
+	Value string
+}
+
+type signalTestSignalParam struct {
+	Message string
+}
+
+func TestSignalWithStartNonPositional(t *testing.T) {
+	q := NewQueue("signal-test-q-nonpositional")
+	wf := NewWorkflow[signalTestParams, signalTestResult](q, "signal-test-wf-nonpositional")
+	sig := NewWorkflowSignal[signalTestSignalParam](&wf, "test-signal")
+
+	mock := &signalWithStartCapture{}
+	c := &Client{Client: mock, namespace: "default"}
+
+	_, err := sig.SignalWithStart(
+		context.Background(), c,
+		client.StartWorkflowOptions{ID: "test-wf-id"},
+		signalTestParams{Name: "Alice", Age: 30},
+		signalTestSignalParam{Message: "hello"},
+	)
+	require.NoError(t, err)
+
+	// Non-positional: the struct is passed as a single argument
+	require.Len(t, mock.capturedWorkflowArgs, 1, "non-positional should pass struct as single arg")
+}
+
+func TestSignalWithStartPositional(t *testing.T) {
+	q := NewQueue("signal-test-q-positional")
+	wf := NewWorkflowPositional[signalTestParams, signalTestResult](q, "signal-test-wf-positional")
+	sig := NewWorkflowSignal[signalTestSignalParam](&wf, "test-signal")
+
+	mock := &signalWithStartCapture{}
+	c := &Client{Client: mock, namespace: "default"}
+
+	_, err := sig.SignalWithStart(
+		context.Background(), c,
+		client.StartWorkflowOptions{ID: "test-wf-id"},
+		signalTestParams{Name: "Alice", Age: 30},
+		signalTestSignalParam{Message: "hello"},
+	)
+	require.NoError(t, err)
+
+	// Positional: the struct fields should be decomposed into separate arguments
+	require.Len(t, mock.capturedWorkflowArgs, 2, "positional should decompose struct into individual field args")
+	require.Equal(t, "Alice", mock.capturedWorkflowArgs[0])
+	require.Equal(t, 30, mock.capturedWorkflowArgs[1])
+}


### PR DESCRIPTION
## Summary

- `SignalWithStart` ignored the workflow's `positional` flag and always sent `workflowParam` as a single struct argument. Every other execution path (`Execute`, `ExecuteChild`, `SetSchedule`) correctly decomposes the struct into individual positional args. This caused deserialization failures for positional workflows.
- Adds unit tests with a mock client verifying the arg decomposition.
- Adds `integration_test/` package with `TestMain` that auto-starts a Temporal dev server via `testsuite.StartDevServer`, plus end-to-end tests proving the fix works on the wire.

## Test plan

- [x] Unit test: `TestSignalWithStartNonPositional` (control) - struct passed as single arg
- [x] Unit test: `TestSignalWithStartPositional` - struct decomposed into individual field args
- [x] Integration test: `TestSignalWithStartPositional` - workflow completes with correct positional args via real Temporal server
- [x] Integration test: `TestSignalWithStartNonPositional` - control case
- [x] All tests pass with `-race`