### PR TITLE
fix: eliminate potential goroutine leak in Worker.Run

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -105,16 +105,15 @@ func (w *Worker) Register(wrk worker.Registry) {
 }
 
 // Run starts the worker. To stop it, cancel the context. This function returns when the worker completes.
-// Make sure to always cancel the context eventually, or a goroutine will be leaked.
 func (w *Worker) Run(ctx context.Context, client *Client, options worker.Options) error {
 	options.DisableRegistrationAliasing = true
 	wrk := worker.New(client.Client, w.queue.name, options)
 	w.Register(wrk)
 
-	interruptCh := make(chan interface{})
-	go func() {
-		<-ctx.Done()
+	interruptCh := make(chan any)
+	stop := context.AfterFunc(ctx, func() {
 		close(interruptCh)
-	}()
+	})
+	defer stop()
 	return wrk.Run(interruptCh)
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,49 @@
+package tempts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+)
+
+func TestWorkerRunReturnsOnContextCancel(t *testing.T) {
+	srv, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
+		LogLevel: "error",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	c, err := NewFromSDK(srv.Client(), "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := NewQueue("worker-cancel-test")
+	wrk, err := NewWorker(q, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- wrk.Run(ctx, c, worker.Options{})
+	}()
+
+	// Let the worker start, then cancel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Worker returned - good.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Worker.Run did not return after context cancellation")
+	}
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -36,13 +36,10 @@ func TestWorkerRunReturnsOnContextCancel(t *testing.T) {
 		done <- wrk.Run(ctx, c, worker.Options{})
 	}()
 
-	// Let the worker start, then cancel.
-	time.Sleep(200 * time.Millisecond)
 	cancel()
 
 	select {
 	case <-done:
-		// Worker returned - good.
 	case <-time.After(5 * time.Second):
 		t.Fatal("Worker.Run did not return after context cancellation")
 	}


### PR DESCRIPTION
## Summary

- Replace the manual goroutine watching `ctx.Done()` with `context.AfterFunc` + `defer stop()`, which ensures cleanup when `wrk.Run` returns regardless of whether the context was cancelled.
- Previously, if `wrk.Run` returned before the context was cancelled, the goroutine would be orphaned. In practice the Temporal worker retries indefinitely so this is a structural improvement rather than an observed bug.
- Removes the doc comment warning about needing to cancel the context to avoid leaks.
- Adds a test verifying Worker.Run returns promptly on context cancellation.

## Test plan

- [x] `TestWorkerRunReturnsOnContextCancel` - starts worker against dev server, cancels context, asserts Run returns
- [x] All existing tests pass with `-race`