### PR TITLE
chore: bump go directive to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vikstrous/tempts
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` from `1.23.0` to `1.26.0` (latest stable).
- Unlocks post-1.23 stdlib for tests — notably the stable `testing/synctest` API (1.25+), which is useful for deterministic concurrency tests without real sleeps.
- `go mod tidy` does not change `go.sum`; no dependency churn.
- No source changes required; `go build ./...`, `go vet ./...`, and `go test -race .` all pass.

## Test plan

- [x] `go mod tidy` — go.sum unchanged
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race .` — pass