### PR TITLE
chore: apply go fix ./...

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -57,21 +57,21 @@ func NewActivityPositional[Param, Return any](q *Queue, name string) Activity[Pa
 	panicIfNotStruct[Param]("NewActivityPositional")
 
 	// Get the type information for the Param struct
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
-	if paramType.Kind() == reflect.Ptr {
+	paramType := reflect.TypeFor[Param]()
+	if paramType.Kind() == reflect.Pointer {
 		paramType = paramType.Elem()
 	}
 
 	// Create a slice of function parameter types: (context.Context, field1Type, field2Type, ...)
 	paramTypes := make([]reflect.Type, paramType.NumField()+1)
-	paramTypes[0] = reflect.TypeOf((*context.Context)(nil)).Elem()
+	paramTypes[0] = reflect.TypeFor[context.Context]()
 	for i := 0; i < paramType.NumField(); i++ {
 		paramTypes[i+1] = paramType.Field(i).Type
 	}
 
 	// Create the function type: func(context.Context, field1Type, field2Type, ...) (Return, error)
-	returnType := reflect.TypeOf((*Return)(nil)).Elem()
-	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	returnType := reflect.TypeFor[Return]()
+	errorType := reflect.TypeFor[error]()
 	fnType := reflect.FuncOf(paramTypes, []reflect.Type{returnType, errorType}, false)
 
 	// Create a function that panics with the message "Function execution not mocked"
@@ -86,8 +86,8 @@ func NewActivityPositional[Param, Return any](q *Queue, name string) Activity[Pa
 }
 
 func panicIfNotStruct[Param any](funcName string) {
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
-	if paramType.Kind() == reflect.Ptr {
+	paramType := reflect.TypeFor[Param]()
+	if paramType.Kind() == reflect.Pointer {
 		paramType = paramType.Elem()
 	}
 	if paramType.Kind() != reflect.Struct {
@@ -96,7 +96,7 @@ func panicIfNotStruct[Param any](funcName string) {
 }
 
 func extractFieldTypes(structType reflect.Type) []reflect.Type {
-	if structType.Kind() == reflect.Ptr {
+	if structType.Kind() == reflect.Pointer {
 		structType = structType.Elem()
 	}
 	if structType.Kind() != reflect.Struct {
@@ -117,9 +117,9 @@ func (a Activity[Param, Return]) WithImplementation(fn func(context.Context, Par
 	}
 
 	// For positional activities, create a wrapper function that converts positional arguments to a struct
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	paramType := reflect.TypeFor[Param]()
 	var fieldTypes []reflect.Type
-	if paramType.Kind() == reflect.Ptr {
+	if paramType.Kind() == reflect.Pointer {
 		fieldTypes = extractFieldTypes(paramType.Elem())
 	} else {
 		fieldTypes = extractFieldTypes(paramType)
@@ -127,8 +127,8 @@ func (a Activity[Param, Return]) WithImplementation(fn func(context.Context, Par
 
 	wrapper := reflect.MakeFunc(
 		reflect.FuncOf(
-			append([]reflect.Type{reflect.TypeOf((*context.Context)(nil)).Elem()}, fieldTypes...),
-			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
+			append([]reflect.Type{reflect.TypeFor[context.Context]()}, fieldTypes...),
+			[]reflect.Type{reflect.TypeFor[Return](), reflect.TypeFor[error]()},
 			false,
 		),
 		func(args []reflect.Value) []reflect.Value {
@@ -136,7 +136,7 @@ func (a Activity[Param, Return]) WithImplementation(fn func(context.Context, Par
 
 			// Create a new instance of the Param struct
 			var paramVal reflect.Value
-			if paramType.Kind() == reflect.Ptr {
+			if paramType.Kind() == reflect.Pointer {
 				paramVal = reflect.New(paramType.Elem())
 				// Fill the struct fields with the positional arguments
 				for i := 0; i < paramType.Elem().NumField(); i++ {
@@ -167,11 +167,11 @@ func (a Activity[Param, Return]) Execute(ctx workflow.Context, param Param) work
 
 	// For positional activities, extract struct fields into separate arguments
 	paramVal := reflect.ValueOf(param)
-	if paramVal.Kind() == reflect.Ptr {
+	if paramVal.Kind() == reflect.Pointer {
 		paramVal = paramVal.Elem()
 	}
 
-	args := make([]interface{}, paramVal.NumField())
+	args := make([]any, paramVal.NumField())
 	for i := 0; i < paramVal.NumField(); i++ {
 		args[i] = paramVal.Field(i).Interface()
 	}

--- a/example/json_decode_error_test.go
+++ b/example/json_decode_error_test.go
@@ -323,8 +323,7 @@ func TestIntegrationDecodeErrorBlocksThenRecovers(t *testing.T) {
 	switchableDecodeFailure.Store(false)
 	t.Log("Phase 2: Decode fixed, starting new worker")
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 	startSwitchableWorker(t, ctx2, c)
 
 	// Wait for the workflow to complete

--- a/replaytest.go
+++ b/replaytest.go
@@ -142,9 +142,9 @@ func (w Workflow[Param, Return]) ReplayWorkflow(historiesBytes []byte, fn func(w
 		return replayWorkflow(historiesBytes, fn, opts)
 	}
 
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	paramType := reflect.TypeFor[Param]()
 	var fieldTypes []reflect.Type
-	if paramType.Kind() == reflect.Ptr {
+	if paramType.Kind() == reflect.Pointer {
 		fieldTypes = extractFieldTypes(paramType.Elem())
 	} else {
 		fieldTypes = extractFieldTypes(paramType)
@@ -153,13 +153,13 @@ func (w Workflow[Param, Return]) ReplayWorkflow(historiesBytes []byte, fn func(w
 	fnVal := reflect.ValueOf(fn)
 	wrapper := reflect.MakeFunc(
 		reflect.FuncOf(
-			append([]reflect.Type{reflect.TypeOf((*workflow.Context)(nil)).Elem()}, fieldTypes...),
-			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
+			append([]reflect.Type{reflect.TypeFor[workflow.Context]()}, fieldTypes...),
+			[]reflect.Type{reflect.TypeFor[Return](), reflect.TypeFor[error]()},
 			false,
 		),
 		func(args []reflect.Value) []reflect.Value {
 			var paramVal reflect.Value
-			if paramType.Kind() == reflect.Ptr {
+			if paramType.Kind() == reflect.Pointer {
 				paramVal = reflect.New(paramType.Elem())
 				for i := 0; i < paramType.Elem().NumField(); i++ {
 					paramVal.Elem().Field(i).Set(args[i+1])

--- a/signal.go
+++ b/signal.go
@@ -102,7 +102,7 @@ func (s *WorkflowSignal[WP, WR, SP]) SignalWithStart(
 		workflowArgs = []any{workflowParam}
 	} else {
 		paramVal := reflect.ValueOf(workflowParam)
-		if paramVal.Kind() == reflect.Ptr {
+		if paramVal.Kind() == reflect.Pointer {
 			paramVal = paramVal.Elem()
 		}
 		workflowArgs = make([]any, paramVal.NumField())

--- a/workflow.go
+++ b/workflow.go
@@ -57,8 +57,8 @@ func (w WorkflowWithImpl[Param, Return]) validate(v *validationState) error {
 }
 
 type testEnvironment interface {
-	ExecuteWorkflow(workflowFn interface{}, args ...interface{})
-	GetWorkflowResult(valuePtr interface{}) error
+	ExecuteWorkflow(workflowFn any, args ...any)
+	GetWorkflowResult(valuePtr any) error
 	GetWorkflowError() error
 }
 
@@ -110,23 +110,23 @@ func NewWorkflowPositional[Param any, Return any](queue *Queue, name string) Wor
 	panicIfNotStruct[Param]("NewWorkflowPositional")
 
 	// Get the type information for the Param struct
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	paramType := reflect.TypeFor[Param]()
 
 	// Create a slice of function parameter types: (context.Context, field1Type, field2Type, ...)
 	var fieldTypes []reflect.Type
-	if paramType.Kind() == reflect.Ptr {
+	if paramType.Kind() == reflect.Pointer {
 		fieldTypes = extractFieldTypes(paramType.Elem())
 	} else {
 		fieldTypes = extractFieldTypes(paramType)
 	}
 
 	paramTypes := make([]reflect.Type, len(fieldTypes)+1)
-	paramTypes[0] = reflect.TypeOf((*workflow.Context)(nil)).Elem()
+	paramTypes[0] = reflect.TypeFor[workflow.Context]()
 	copy(paramTypes[1:], fieldTypes)
 
 	// Create the function type: func(workflow.Context, field1Type, field2Type, ...) (Return, error)
-	returnType := reflect.TypeOf((*Return)(nil)).Elem()
-	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	returnType := reflect.TypeFor[Return]()
+	errorType := reflect.TypeFor[error]()
 	fnType := reflect.FuncOf(paramTypes, []reflect.Type{returnType, errorType}, false)
 
 	// Create a function that panics with the message "Function execution not mocked"
@@ -169,9 +169,9 @@ func (w Workflow[Param, Return]) WithImplementation(fn func(workflow.Context, Pa
 	}
 
 	// For positional workflows, create a wrapper function that converts positional arguments to a struct
-	paramType := reflect.TypeOf((*Param)(nil)).Elem()
+	paramType := reflect.TypeFor[Param]()
 	var fieldTypes []reflect.Type
-	if paramType.Kind() == reflect.Ptr {
+	if paramType.Kind() == reflect.Pointer {
 		fieldTypes = extractFieldTypes(paramType.Elem())
 	} else {
 		fieldTypes = extractFieldTypes(paramType)
@@ -179,8 +179,8 @@ func (w Workflow[Param, Return]) WithImplementation(fn func(workflow.Context, Pa
 
 	wrapper := reflect.MakeFunc(
 		reflect.FuncOf(
-			append([]reflect.Type{reflect.TypeOf((*workflow.Context)(nil)).Elem()}, fieldTypes...),
-			[]reflect.Type{reflect.TypeOf((*Return)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()},
+			append([]reflect.Type{reflect.TypeFor[workflow.Context]()}, fieldTypes...),
+			[]reflect.Type{reflect.TypeFor[Return](), reflect.TypeFor[error]()},
 			false,
 		),
 		func(args []reflect.Value) []reflect.Value {
@@ -188,7 +188,7 @@ func (w Workflow[Param, Return]) WithImplementation(fn func(workflow.Context, Pa
 
 			// Create a new instance of the Param struct
 			var paramVal reflect.Value
-			if paramType.Kind() == reflect.Ptr {
+			if paramType.Kind() == reflect.Pointer {
 				paramVal = reflect.New(paramType.Elem())
 				// Fill the struct fields with the positional arguments
 				for i := 0; i < paramType.Elem().NumField(); i++ {
@@ -247,11 +247,11 @@ func (w Workflow[Param, Return]) Execute(ctx context.Context, temporalClient *Cl
 
 	// For positional workflows, extract struct fields into separate arguments
 	paramVal := reflect.ValueOf(param)
-	if paramVal.Kind() == reflect.Ptr {
+	if paramVal.Kind() == reflect.Pointer {
 		paramVal = paramVal.Elem()
 	}
 
-	args := make([]interface{}, paramVal.NumField())
+	args := make([]any, paramVal.NumField())
 	for i := 0; i < paramVal.NumField(); i++ {
 		args[i] = paramVal.Field(i).Interface()
 	}
@@ -278,11 +278,11 @@ func (w Workflow[Param, Return]) ExecuteChild(ctx workflow.Context, opts workflo
 
 	// For positional workflows, extract struct fields into separate arguments
 	paramVal := reflect.ValueOf(param)
-	if paramVal.Kind() == reflect.Ptr {
+	if paramVal.Kind() == reflect.Pointer {
 		paramVal = paramVal.Elem()
 	}
 
-	args := make([]interface{}, paramVal.NumField())
+	args := make([]any, paramVal.NumField())
 	for i := 0; i < paramVal.NumField(); i++ {
 		args[i] = paramVal.Field(i).Interface()
 	}
@@ -302,7 +302,7 @@ func (w Workflow[Param, Return]) SetSchedule(ctx context.Context, temporalClient
 	} else {
 		// For positional workflows, extract struct fields into separate arguments
 		paramVal := reflect.ValueOf(param)
-		if paramVal.Kind() == reflect.Ptr {
+		if paramVal.Kind() == reflect.Pointer {
 			paramVal = paramVal.Elem()
 		}
 


### PR DESCRIPTION
## Summary
- Applies `go fix ./...` after the Go 1.26 directive bump
- Modernizes `reflect.TypeOf((*T)(nil)).Elem()` → `reflect.TypeFor[T]()`
- Replaces `reflect.Ptr` with `reflect.Pointer`
- Uses `t.Context()` in the example decode-error test

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./...`